### PR TITLE
fix: Cloud Agent が認識する copilot-setup-steps.yml に修正

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,10 +1,22 @@
 name: "Copilot Setup Steps"
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
 
 jobs:
-  copilot-setup:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     steps:
       - name: チェックアウト
         uses: actions/checkout@v4


### PR DESCRIPTION
## 問題
Cloud Agent はジョブ名が `copilot-setup-steps` でないと環境セットアップを認識しない。
現状は `copilot-setup` になっており、Cloud Agent が Java/Maven 環境を使えない状態。

## 修正内容
- ジョブ名: `copilot-setup` → **`copilot-setup-steps`**（必須名称）
- トリガー: `push`/`pull_request` の paths フィルタ追加（変更時に自動検証）
- `permissions: contents: read` を明示

## 参考
https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/customize-the-agent-environment